### PR TITLE
Fix TLS support in 'mc' and 'smoke-tests' jobs

### DIFF
--- a/jobs/mc/spec
+++ b/jobs/mc/spec
@@ -3,6 +3,7 @@ name: mc
 
 templates:
   run.erb: bin/run
+  ca.crt.erb: config/certs/CAs/ca.crt
 
 consumes:
 - name: minio
@@ -13,4 +14,21 @@ packages:
 
 properties:
   script:
-    description: bash script to run mc commands
+    description: |
+      BASH script to run mc commands.
+
+      The pre-configured host configuration is called 'myminio'. For example,
+      if you need to create a bucket, you can write such code:
+
+          mc mb myminio/((bucket_name))
+
+      Support for TLS-enabled minio server is provided with a pre-configured
+      config folder that is abailable at '/var/vcap/jobs/mc/config'. There is
+      located the custom Certificate Athority certs that the 'mc' should
+      trust. So, in a TLS-enabled server, the example bucket creation above
+      becomes:
+
+          mc --config-folder /var/vcap/jobs/mc/config mb myminio/((bucket_name))
+
+      Note: we advise you to use the '--ignore-existing' flag to 'mc' when
+      writing bucket creation code as above.

--- a/jobs/mc/templates/ca.crt.erb
+++ b/jobs/mc/templates/ca.crt.erb
@@ -1,0 +1,1 @@
+<%= link('minio').p("ca_cert", "") -%>

--- a/jobs/mc/templates/run.erb
+++ b/jobs/mc/templates/run.erb
@@ -1,11 +1,19 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 export PATH=$PATH:/var/vcap/packages/mc
 
-ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
-SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
-PORT="<%= link('minio').p('port') %>"
-HOST="<%= link('minio').instances[0].address %>"
+ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
+SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
+PORT=<%= esc(link('minio').p('port')) %>
+HOST=<%= esc(link('minio').instances[0].address) %>
+
 export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 bash <<EOF

--- a/jobs/mc/templates/run.erb
+++ b/jobs/mc/templates/run.erb
@@ -13,8 +13,9 @@ ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
 SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
 PORT=<%= esc(link('minio').p('port')) %>
 HOST=<%= esc(link('minio').instances[0].address) %>
+PROTOCOL=<%= esc(link('minio').p('server_cert', nil) ? 'https' : 'http') %>
 
-export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
+export MC_HOSTS_myminio=$PROTOCOL://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 bash <<EOF
 <%= p("script") %>

--- a/jobs/minio-azure/templates/ctl.erb
+++ b/jobs/minio-azure/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-azure
 LOG_DIR=/var/vcap/sys/log/minio-azure
@@ -10,15 +17,15 @@ BINPATH=/var/vcap/packages/minio
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${STORE_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${STORE_DIR}
 
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' azure \
+    exec ${BINPATH}/minio gateway --address :<%= esc(p("port")) %> azure \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-azure/templates/health_check.erb
+++ b/jobs/minio-azure/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-gcs/templates/ctl.erb
+++ b/jobs/minio-gcs/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-gcs
 LOG_DIR=/var/vcap/sys/log/minio-gcs
@@ -10,17 +17,17 @@ BINPATH=/var/vcap/packages/minio
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${STORE_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${STORE_DIR}
 
-echo <%= p("credential.googlecredentials") %> | base64 -d > $CONFIG_DIR/google-credentials.json
+echo <%= esc(p("credential.googlecredentials")) %> | base64 -d > $CONFIG_DIR/google-credentials.json
 export GOOGLE_APPLICATION_CREDENTIALS=$CONFIG_DIR/google-credentials.json
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' gcs \
+    exec ${BINPATH}/minio gateway --address :<%= esc(p("port")) %> gcs \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-gcs/templates/health_check.erb
+++ b/jobs/minio-gcs/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-nas/templates/ctl.erb
+++ b/jobs/minio-nas/templates/ctl.erb
@@ -1,9 +1,16 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-nas
 LOG_DIR=/var/vcap/sys/log/minio-nas
-DATA_DIR='<%= p("data_dir") %>'
-CONFIG_DIR='<%= p("config_dir") %>'
+DATA_DIR=<%= esc(p("data_dir")) %>
+CONFIG_DIR=<%= esc(p("config_dir")) %>
 PIDFILE=${RUN_DIR}/pid
 BINPATH=/var/vcap/packages/minio
 
@@ -14,9 +21,9 @@ fi
 mkdir -p ${RUN_DIR} ${LOG_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR
 
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
@@ -36,7 +43,7 @@ case $1 in
     echo "NAS share mounted! Starting Minio." >> ${LOG_DIR}/minio-server.stdout.log
 
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway -C $CONFIG_DIR --address ':<%= p("port") %>' nas $DATA_DIR \
+    exec ${BINPATH}/minio gateway -C $CONFIG_DIR --address :<%= esc(p("port")) %> nas $DATA_DIR \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-nas/templates/health_check.erb
+++ b/jobs/minio-nas/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-server/spec
+++ b/jobs/minio-server/spec
@@ -23,6 +23,8 @@ provides:
   - port
   - credential.accesskey
   - credential.secretkey
+  - server_cert
+  - ca_cert
 
 properties:
   credential.accesskey:

--- a/jobs/minio-server/templates/config.json.erb
+++ b/jobs/minio-server/templates/config.json.erb
@@ -1,10 +1,11 @@
+<% require 'json' -%>
 {
 	"version": "14",
 	"credential": {
-		"accessKey": "<%= p("credential.accesskey") %>",
-		"secretKey": "<%= p("credential.secretkey") %>"
+		"accessKey": <%= p('credential.accesskey').to_json %>,
+		"secretKey": <%= p('credential.secretkey').to_json %>
 	},
-	"region": "<%= p("region") %>",
+	"region": <%= p('region').to_json %>,
 	"browser": "on",
 	"logger": {
 		"console": {

--- a/jobs/minio-server/templates/ctl.erb
+++ b/jobs/minio-server/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-server
 LOG_DIR=/var/vcap/sys/log/minio-server
@@ -40,7 +47,7 @@ end.else do
   nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.address}${DATA_DIR}/" }
 end %>
 
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
@@ -48,8 +55,8 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec ${BINPATH}/minio server -C $CONFIG_DIR \
-         --address ':<%= p("port") %>' \
-         <% if link("minio-server").instances.length > 1 %><%= nodes.map{ |n| "\"#{n}\"" }.join(' ') %><% else %>${DATA_DIR}/<% end %> \
+         --address :<%= esc(p("port")) %> \
+         <% if link("minio-server").instances.length > 1 %><%= esc(nodes.map{ |n| "\"#{n}\"" }.join(' ')) %><% else %>${DATA_DIR}/<% end %> \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
 

--- a/jobs/minio-server/templates/ctl.erb
+++ b/jobs/minio-server/templates/ctl.erb
@@ -42,9 +42,9 @@ rm -f ${CONFIG_DIR}/certs/CAs/ca.crt
 
 <% nodes = nil %>
 <% if_p('dns_alias') do |dns_alias|
-  nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.id}.#{dns_alias}${DATA_DIR}/" }
+  nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.id}.#{dns_alias}" }
 end.else do
-  nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.address}${DATA_DIR}/" }
+  nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.address}" }
 end %>
 
 export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
@@ -56,7 +56,7 @@ case $1 in
 
     exec ${BINPATH}/minio server -C $CONFIG_DIR \
          --address :<%= esc(p("port")) %> \
-         <% if link("minio-server").instances.length > 1 %><%= esc(nodes.map{ |n| "\"#{n}\"" }.join(' ')) %><% else %>${DATA_DIR}/<% end %> \
+         <% if link("minio-server").instances.length > 1 %><%= nodes.map{ |n| "#{esc(n)}${DATA_DIR}/" }.join(' ') %><% else %>${DATA_DIR}/<% end %> \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
 

--- a/jobs/minio-server/templates/health_check.erb
+++ b/jobs/minio-server/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -3,6 +3,7 @@ name: smoke-tests
 
 templates:
   run.erb: bin/run
+  ca.crt.erb: config/certs/CAs/ca.crt
 
 consumes:
 - name: minio

--- a/jobs/smoke-tests/templates/ca.crt.erb
+++ b/jobs/smoke-tests/templates/ca.crt.erb
@@ -1,0 +1,1 @@
+<%= link('minio').p("ca_cert", "") -%>

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -7,14 +7,15 @@
   end
 %>
 
-MC=/var/vcap/packages/mc/mc
+MC="/var/vcap/packages/mc/mc --config-folder /var/vcap/jobs/smoke-tests/config"
 
 ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
 SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
 PORT=<%= esc(link('minio').p('port')) %>
 HOST=<%= esc(link('minio').instances[0].address) %>
+PROTOCOL=<%= esc(link('minio').p('server_cert', nil) ? 'https' : 'http') %>
 
-export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
+export MC_HOSTS_myminio=$PROTOCOL://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 # MakeBucket
 $MC mb myminio/test

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -17,50 +17,26 @@ PROTOCOL=<%= esc(link('minio').p('server_cert', nil) ? 'https' : 'http') %>
 
 export MC_HOSTS_myminio=$PROTOCOL://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
+set -e
+
 # MakeBucket
 $MC mb myminio/test
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
 # PUT Object
 $MC cp /etc/passwd myminio/test
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
 # GET Object
 uploadedFile=`$MC cat myminio/test/passwd`
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
 localFile=`cat /etc/passwd`
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
-if [ "$uploadedFile" != "$localFile" ]
-then
-    exit 1
-fi
+# Assert both contents are identic
+[ "$uploadedFile" == "$localFile" ]
 
 # Remove Object
 $MC rm --force myminio/test/passwd
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
 # Remove Bucket
 $MC rm --force myminio/test
-if [ $? -ne 0 ]
-then
-    exit $?
-fi
 
 exit 0

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -1,11 +1,19 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 MC=/var/vcap/packages/mc/mc
 
-ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
-SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
-PORT="<%= link('minio').p('port') %>"
-HOST="<%= link('minio').instances[0].address %>"
+ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
+SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
+PORT=<%= esc(link('minio').p('port')) %>
+HOST=<%= esc(link('minio').instances[0].address) %>
+
 export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 # MakeBucket


### PR DESCRIPTION
Hi,

**NOTICE:** this PR builds on top of #108, which should be merged first.

Prior to this PR, when TLS was enabled in the `minio-server` job, the `mc` and `smoke-tests` jobs were not able to communicate with it, due to the hard-wired `http` scheme, and missing certificate authority to trust.

So, here we expose both server and CA certificates in the `minio-server` link, and use those properties for the `mc` and `smoke-tests` errands to properly access minio server. We also document in the `mc` job spec how the the `mc` command should be leveraged properly.

Working on this topic, we faced issues with smoke tests, that have been fixed. This is because `$?` is reset to `0` when the `[ $? -ne 0 ]` test succeeds, so the `exit $0` statements would never return a non-zero exit status.

We could have fixed this issue with such code:
```
$MC mb myminio/test
exit_status=$?
if [ $exit_status -ne 0 ]; then
    exit $exit_status
fi
```
But the script reads better when adopting the `set -e` option, which allows us to remove all the boilerplate code.

Best,
Benjamin